### PR TITLE
Show how to debug-print arrays and structures

### DIFF
--- a/chapter4/slices/src/main.rs
+++ b/chapter4/slices/src/main.rs
@@ -6,7 +6,26 @@ fn main() {
     // let h = &hello[..];
     // println!("{}", h);
 
-    // can only print integers, not full arrays
     let a = [0, 1, 2, 3];
-    println!("{}", a[1]);
+    // :? is "debug print"
+    println!("{:?}", a);
+    // :#? is "debug pretty print"
+    println!("{:#?}", a);
+    // for more formatting rules, check out https://doc.rust-lang.org/std/fmt/
+    
+    
+    // the thing you are trying to print has to be debug-printable:
+    struct NotPrintable { internal: u32 };
+    let not_printable = NotPrintable { internal: 5 };
+    // println!("{:?}", not_printable); // won't work
+    
+    
+    #[derive(Debug)] // macro to generate code to make "Printable" implement the "Debug" trait
+    struct Printable { internal: u32 };
+    
+    let printable = Printable { internal: 5 };
+    println!("{:?}", printable); // shows "Printable { internal: 5 }"
+    println!("{:#?}", printable); // shows: "Printable {
+                                  //              internal: 5
+                                  //         }"
 }


### PR DESCRIPTION
Rust can debug-print and display-print stuff. You've only learned the "display-print" way with `{}`, the book hasn't (yet?) covered debug-printing.